### PR TITLE
Fix nasty, nasty regression introduced by b5931f4

### DIFF
--- a/pythonrc.py
+++ b/pythonrc.py
@@ -294,7 +294,7 @@ class ImprovedConsole(InteractiveConsole, object):
         def complete_wrapper(text, state):
             line = readline.get_line_buffer()
             if line == '' or line.isspace():
-                return self.tab
+                return None if state > 0 else self.tab
             if state == 0 and line.startswith(('from ', 'import ')):
                 words = line.split()
                 if len(words) <= 2:

--- a/test_pythonrc.py
+++ b/test_pythonrc.py
@@ -112,6 +112,7 @@ class TestImprovedConsole(TestCase):
         # - no leading characters
         with patch.object(rl, 'get_line_buffer', return_value='\t'):
             self.assertEqual(completer('\t', 0), '    ')
+            self.assertEqual(completer('', 1), None)
 
         # - keyword completion
         with patch.object(rl, 'get_line_buffer', return_value='cla\t'):


### PR DESCRIPTION
The completer function would never terminate if completion was attempted
on an empty line / line with preceding whitespace.