### PR TITLE
Fix Issue #21 - Issue .push() on start of new expression rather at end of current expression

### DIFF
--- a/pythonrc.py
+++ b/pythonrc.py
@@ -453,10 +453,13 @@ class ImprovedConsole(InteractiveConsole, object):
                 self.write(cyan("... {}".format(stmt)))
             if not stripped.startswith('#'):
                 line = stmt.strip('\n')
-                self.push(line)
+                if line and not line[0].isspace():
+                    super(ImprovedConsole, self).push('')
+                self.buffer.append(line)
                 if not skip_history:
                     readline.add_history(line)
             previous = stripped
+        super(ImprovedConsole, self).push('')
 
     def lookup(self, name, namespace=None):
         """Lookup the (dotted) object specified with the string `name`

--- a/pythonrc.py
+++ b/pythonrc.py
@@ -454,12 +454,15 @@ class ImprovedConsole(InteractiveConsole, object):
             if not stripped.startswith('#'):
                 line = stmt.strip('\n')
                 if line and not line[0].isspace():
-                    super(ImprovedConsole, self).push('')
+                    source = "\n".join(self.buffer)
+                    more = self.runsource(source, self.filename)
+                    if not more:
+                        self.resetbuffer()
                 self.buffer.append(line)
                 if not skip_history:
                     readline.add_history(line)
             previous = stripped
-        super(ImprovedConsole, self).push('')
+        self.push('')
 
     def lookup(self, name, namespace=None):
         """Lookup the (dotted) object specified with the string `name`

--- a/test_pythonrc.py
+++ b/test_pythonrc.py
@@ -22,6 +22,23 @@ os.environ['SKIP_PYMP'] = "1"
 
 import pythonrc
 
+EDIT_CMD_TEST_LINES="""
+
+x = 42
+class Foo(object):
+
+
+    def first(self):
+        pass
+
+
+    def second(self):
+
+        pass
+
+x += 1
+"""
+
 
 class TestImprovedConsole(TestCase):
 
@@ -266,3 +283,18 @@ class TestImprovedConsole(TestCase):
                                               'HOME': '/home/me/'}):
             self.pymp.process_sh_cmd('cd {path}')
             mocked_chdir.assert_called_once_with('/home/me/dummy/location')
+
+    def test_exec_from_file(self):
+        """Test exec from file with multiple newlines in code blocks"""
+        pymp = pythonrc.ImprovedConsole()
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tempfl:
+            tempfl.write(EDIT_CMD_TEST_LINES)
+            tempfl.close()
+            pymp._exec_from_file(tempfl.name)
+            os.unlink(tempfl.name)
+
+            self.assertIn('Foo', pymp.locals)
+            self.assertIn('first', pymp.locals['Foo'].__dict__)
+            self.assertIn('second', pymp.locals['Foo'].__dict__)
+            self.assertIn('x', pymp.locals)
+            self.assertEqual(pymp.locals['x'], 43)

--- a/test_pythonrc.py
+++ b/test_pythonrc.py
@@ -36,7 +36,16 @@ class Foo(object):
 
         pass
 
-x += 1
+
+if x == 43:
+    raise Exception()
+elif x == 42:
+    x += 1
+else:
+    raise Exception()
+
+f = Foo()
+
 """
 
 
@@ -297,4 +306,5 @@ class TestImprovedConsole(TestCase):
             self.assertIn('first', pymp.locals['Foo'].__dict__)
             self.assertIn('second', pymp.locals['Foo'].__dict__)
             self.assertIn('x', pymp.locals)
+            self.assertIn('f', pymp.locals)
             self.assertEqual(pymp.locals['x'], 43)


### PR DESCRIPTION
The issue being fixed has been detailed in Issue #21. This patchset
fixes the issue by deferring the evaluation until a new statement is
detected rather than detecting the end of current statement.