### PR TITLE
Skip exec after editing session history if editor exits with an error code.

### DIFF
--- a/pythonrc.py
+++ b/pythonrc.py
@@ -419,6 +419,11 @@ class ImprovedConsole(InteractiveConsole, object):
         hook = None if config['AUTO_INDENT'] else self.auto_indent_hook
         readline.set_pre_input_hook(hook)
         config['AUTO_INDENT'] = bool(hook)
+        print(
+            grey('# Auto-Indent has been {}'.format(
+                'enabled' if config['AUTO_INDENT'] else 'disabled'
+            ), bold=False)
+        )
         return ''
 
     def raw_input(self, prompt=''):

--- a/pythonrc.py
+++ b/pythonrc.py
@@ -86,7 +86,7 @@ from functools import partial
 from tempfile import NamedTemporaryFile
 
 
-__version__ = "0.8.3"
+__version__ = "0.8.4"
 
 
 config = dict(

--- a/test_pythonrc.py
+++ b/test_pythonrc.py
@@ -51,6 +51,8 @@ else:
 
 f = Foo()
 
+1 + '2'
+z = 123
 """
 
 
@@ -339,10 +341,11 @@ class TestImprovedConsole(TestCase):
             self.assertIn('x', pymp.locals)
             self.assertIn('f', pymp.locals)
             self.assertEqual(pymp.locals['x'], 43)
+            self.assertNotIn('z', pymp.locals)
 
         with tempfile.NamedTemporaryFile(mode='w') as tempfl:
             pythonrc.readline.write_history_file(tempfl.name)
-            expected = filter(None, EDIT_CMD_TEST_LINES.splitlines())
+            expected = filter(None, EDIT_CMD_TEST_LINES.splitlines()[:-1])
             recieved = filter(None, map(str.rstrip, open(tempfl.name)))
             self.assertEqual(list(expected), list(recieved))
 


### PR DESCRIPTION
Took inspiration how git behaves for commit, difftool etc -- if $EDITOR exits
with an error code (eg: you exit vim with :cq), the action that would normally
follow the edit operation is skipped.

Also couple of comments fixed for clarity.