### PR TITLE
Complete refactor - targetting python version 3.8+

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+max-line-length = 100
+# E402: module level import not at top of file
+# E221: multiple spaces before operator
+# E251: unexpected spaces around keyword / parameter equals
+ignore = E402,E221,E251

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,13 @@ not designed to be used as a separate interactive environment. The intent is to
 keep it as a single file and use it as any other rcfile. This script relies
 solely on the standard python library and will always remain that way.
 
+.. note::
+
+    This branch targets python-3.8+ . If you wish to use/try this out with an
+    earlier version of python please use the support/2.x branch. Any new
+    development will be done on this version but I'm happy to fix any reported
+    bugs on the support/2.x branch.
+
 Demo
 =====
 |demo|
@@ -50,7 +57,7 @@ provides:
 
   * edit the session or a file in your `$EDITOR` (the ``\e`` command)
 
-    - without no arguments, opens your `$EDITOR` with the session hstory
+    - with no arguments, opens your `$EDITOR` with the session hstory
     - with filename argument, opens the file in your `$EDITOR`
     - with object as an argument, opens the source code for the object in `$EDITOR`
 

--- a/pythonrc.py
+++ b/pythonrc.py
@@ -696,8 +696,16 @@ class ImprovedConsole(InteractiveConsole, object):
             for line_no, line in enumerate(src_lines, offset+1):
                 self.write(cyan("{0:03d}: {1}".format(line_no, line)))
 
-    def process_help_cmd(self, arg=''):
-        print(cyan(self.__doc__).format(**config))
+    def process_help_cmd(self, arg):
+        if arg:
+            if keyword.iskeyword(arg):
+                self.push('help("{}")'.format(arg))
+            elif arg in self.commands:
+                self.commands[arg]('-h')
+            else:
+                self.push('help({})'.format(arg))
+        else:
+            print(cyan(self.__doc__).format(**config))
 
     def interact(self):
         """A forgiving wrapper around InteractiveConsole.interact()

--- a/pythonrc.py
+++ b/pythonrc.py
@@ -59,11 +59,6 @@ try:
 except NameError:
     pass
 
-try:
-    import builtins
-except ImportError:
-    import __builtin__ as builtins
-
 import atexit
 import glob
 import importlib
@@ -130,7 +125,9 @@ else:
         sloc = spec.submodule_search_locations
         if orig and not orig.endswith('/__init__.py'):
             return orig
-        if sloc.submodule_search_locations:
+        if isinstance(sloc, list):
+            return sloc[0]
+        elif sloc.submodule_search_locations:
             return sloc.submodule_search_locations[0]
         return orig
 
@@ -305,9 +302,9 @@ class ImprovedConsole(InteractiveConsole, object):
                         rows, cols = map(int, subprocess.check_output(['stty', 'size']).split())
                     except:
                         cols = 80
-                builtins._ = value
                 formatted = format_func(value, width=cols)
                 print(color_dict(formatted) if issubclass(type(value), dict) else blue(formatted))
+            self.locals['_'] = value
 
         sys.displayhook = pprint_callback
 
@@ -668,7 +665,7 @@ class ImprovedConsole(InteractiveConsole, object):
                     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                     (out, err), rc = (process.communicate(), process.returncode)
                     print (red(err.decode('utf-8')) if err else green(out.decode('utf-8'), bold=False))
-                    builtins._ = cmd_exec(out, err, rc)
+                    self.locals['_'] = cmd_exec(out, err, rc)
                     del cmd_exec
             except:
                 self.showtraceback()

--- a/pythonrc.py
+++ b/pythonrc.py
@@ -658,7 +658,7 @@ class ImprovedConsole(InteractiveConsole, object):
                     os.chdir(os.path.expanduser(os.path.expandvars(' '.join(cmd[1:]) or '${HOME}')))
                 else:
                     cmd_exec = namedtuple('CmdExec', ['out', 'err', 'rc'])
-                    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=os.environ)
                     (out, err), rc = (process.communicate(), process.returncode)
                     print (red(err.decode('utf-8')) if err else green(out.decode('utf-8'), bold=False))
                     self.locals['_'] = cmd_exec(out, err, rc)

--- a/test_pythonrc.py
+++ b/test_pythonrc.py
@@ -382,3 +382,16 @@ class TestImprovedConsole(TestCase):
 
         self.assertIs(self.pymp.lookup('subprocess'), None)
         self.assertIs(self.pymp.lookup('subprocess.Popen'), None)
+
+    def test_process_help_cmd(self):
+        with patch('sys.stdout', new_callable=StringIO) as mock_stderr:
+            self.pymp.process_help_cmd('abs')
+            output = sys.stdout.getvalue()
+            self.assertTrue(output.startswith("Help on built-in function abs"))
+
+        with patch('sys.stdout', new_callable=StringIO) as mock_stderr:
+            self.pymp.process_help_cmd('')
+            self.assertEqual(
+                pythonrc.cyan(self.pymp.__doc__.format(**pythonrc.config)),
+                sys.stdout.getvalue().strip()
+            )

--- a/test_pythonrc.py
+++ b/test_pythonrc.py
@@ -4,7 +4,7 @@ import os
 import sys
 import tempfile
 
-from unittest import TestCase, skipIf, skipUnless
+from unittest import TestCase, skipIf, skipUnless, main
 
 try:
     from itertools import zip_longest
@@ -316,7 +316,8 @@ class TestImprovedConsole(TestCase):
             mocked_popen.assert_called_once_with(
                 ['ls', '-l', '/dummy/location'],
                 stdout=pythonrc.subprocess.PIPE,
-                stderr=pythonrc.subprocess.PIPE
+                stderr=pythonrc.subprocess.PIPE,
+                env=os.environ
             )
             mocked_popen.return_value.communicate.assert_called_once_with()
 
@@ -395,3 +396,7 @@ class TestImprovedConsole(TestCase):
                 pythonrc.cyan(self.pymp.__doc__.format(**pythonrc.config)),
                 sys.stdout.getvalue().strip()
             )
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
* Target python version is now 3.8+. For any previous release please use the [support/py2.x](https://github.com/lonetwin/pythonrc/tree/support/py2.x) branch.
* Separated out the completion code into its own class `ImprovedCompleter`. Hopefully the code is now easier to read and make your own.
* Used all new available toys :-) ..including f-strings, walrus operators, cached_property, SimpleNamespace and a lot more
* Functionally ~almost~ nothing has changed (as evidenced by the (only cosmetic) updates to tests), except...
    - Issue #24 is finally fixed ! (finally learned about `sys.builtin_module_names`)
    - With multiple python shells running, we finally get history from all the shells stored (not just the one from the last shell to write to the history -- thanks to the new `readline.append_history_file()`
* pythonrc is now flake8 compliant (with some execeptions)
    
Tests refactoring to come in a later release.