### PR TITLE
New command to toggle running the `asyncio` loop (similar to `python -m asyncio`) !

### DIFF
--- a/pythonrc.py
+++ b/pythonrc.py
@@ -56,7 +56,7 @@ enabled however it does not do pathname completion
 try:
     import sys
 
-    __IPYTHON__ and sys.exit(0)
+    __IPYTHON__ and sys.exit(0)  # type: ignore
 except NameError:
     pass
 
@@ -244,6 +244,16 @@ class ImprovedCompleter(rlcompleter.Completer):
             return None
 
 
+def _doc_to_usage(method):
+    def inner(self, arg):
+        arg = arg.strip()
+        if arg.startswith(("-h", "--help")):
+            return self.writeline(blue(method.__doc__.strip()))
+        return method(self, arg)
+
+    return inner
+
+
 class ImprovedConsole(InteractiveConsole):
     """
     Welcome to lonetwin's pimped up python prompt
@@ -306,15 +316,6 @@ class ImprovedConsole(InteractiveConsole):
                 "|".join(re.escape(cmd) for cmd in self.commands)
             )
         )
-
-    def _doc_to_usage(method):
-        def inner(self, arg):
-            arg = arg.strip()
-            if arg.startswith(("-h", "--help")):
-                return self.writeline(blue(method.__doc__.strip()))
-            return method(self, arg)
-
-        return inner
 
     def init_color_functions(self):
         """Populates globals dict with some helper functions for colorizing text"""
@@ -826,5 +827,5 @@ class ImprovedConsole(InteractiveConsole):
 if not os.getenv("SKIP_PYMP"):
     # - create our pimped out console and fire it up !
     pymp = ImprovedConsole(locals=CLEAN_NS)
-    pymp.locals["__pymp__"] = pymp
+    CLEAN_NS["__pymp__"] = pymp
     pymp.interact()

--- a/pythonrc.py
+++ b/pythonrc.py
@@ -661,11 +661,13 @@ class ImprovedConsole(InteractiveConsole):
                 return self.writeline(e)
         else:
             # - make a list of all lines in history, commenting any non-blank lines.
-            history = self.session_history or open(config.HISTFILE)
+            if not (history := self.session_history):
+                history = open(config.HISTFILE).readlines()
             filename = self._mktemp_buffer(
                 f"# {line}" if line.strip() else ""
                 for line in (line.strip("\n") for line in history)
             )
+            line_num_opt = config.LINE_NUM_OPT.format(line_no=len(history))
 
         # - shell out to the editor
         rc = os.system(f"{config.EDITOR} {line_num_opt} {filename}")

--- a/pythonrc.py
+++ b/pythonrc.py
@@ -55,6 +55,7 @@ enabled however it does not do pathname completion
 # - Exit if being called from within ipython
 try:
     import sys
+
     __IPYTHON__ and sys.exit(0)
 except NameError:
     pass
@@ -85,27 +86,27 @@ __version__ = "0.9.0"
 
 
 config = SimpleNamespace(
-    ONE_INDENT  = '    ',  # what should we use for indentation ?
-    HISTFILE    = os.path.expanduser("~/.python_history"),
-    HISTSIZE    = -1,
-    EDITOR      = os.getenv('EDITOR', 'vi'),
-    SHELL       = os.getenv('SHELL', '/bin/bash'),
-    EDIT_CMD    = r'\e',
-    SH_EXEC     = '!',
-    DOC_CMD     = '?',
-    DOC_URL     = "https://docs.python.org/{sys.version_info.major}/search.html?q={term}",
-    HELP_CMD    = r'\h',
-    LIST_CMD    = r'\l',
-    AUTO_INDENT = True,     # - Should we auto-indent by default
-    VENV_RC     = os.getenv("VENV_RC", ".venv_rc.py"),
+    ONE_INDENT="    ",  # what should we use for indentation ?
+    HISTFILE=os.path.expanduser("~/.python_history"),
+    HISTSIZE=-1,
+    EDITOR=os.getenv("EDITOR", "vi"),
+    SHELL=os.getenv("SHELL", "/bin/bash"),
+    EDIT_CMD=r"\e",
+    SH_EXEC="!",
+    DOC_CMD="?",
+    DOC_URL="https://docs.python.org/{sys.version_info.major}/search.html?q={term}",
+    HELP_CMD=r"\h",
+    LIST_CMD=r"\l",
+    AUTO_INDENT=True,  # - Should we auto-indent by default
+    VENV_RC=os.getenv("VENV_RC", ".venv_rc.py"),
     # - option to pass to the editor to open a file at a specific
     # `line_no`. This is used when the EDIT_CMD is invoked with a python
     # object to open the source file for the object.
     LINE_NUM_OPT="+{line_no}",
     # - Run-time toggle for auto-indent command (eg: when pasting code)
-    TOGGLE_AUTO_INDENT_CMD = r'\\',
+    TOGGLE_AUTO_INDENT_CMD=r"\\",
     # - should path completion expand ~ using os.path.expanduser()
-    COMPLETION_EXPANDS_TILDE = True,
+    COMPLETION_EXPANDS_TILDE=True,
     # - when executing edited history, should we also print comments
     POST_EDIT_PRINT_COMMENTS = True,
     # - Attempt to auto-import top-level module names on NameError
@@ -123,9 +124,9 @@ class ImprovedCompleter(rlcompleter.Completer):
         super().__init__(namespace)
         # - remove '/' and '~' from delimiters to help with path completion
         completer_delims = readline.get_completer_delims()
-        completer_delims = completer_delims.replace('/', '')
+        completer_delims = completer_delims.replace("/", "")
         if config.COMPLETION_EXPANDS_TILDE:
-            completer_delims = completer_delims.replace('~', '')
+            completer_delims = completer_delims.replace("~", "")
         readline.set_completer_delims(completer_delims)
         self.matches = []
 
@@ -134,7 +135,10 @@ class ImprovedCompleter(rlcompleter.Completer):
         """Given a package name, return a list of it's sub-modules."""
         spec = importlib.util.find_spec(pkg)
         locs = [spec.origin] if not spec.parent else spec.submodule_search_locations
-        return [pkg.name for pkg in pkgutil.walk_packages(locs, f'{pkg}.', onerror=lambda _: None)]
+        return [
+            pkg.name
+            for pkg in pkgutil.walk_packages(locs, f"{pkg}.", onerror=lambda _: None)
+        ]
 
     @cached_property
     def pkglist(self):
@@ -142,8 +146,10 @@ class ImprovedCompleter(rlcompleter.Completer):
 
     @cached_property
     def modlist(self):
-        modlist = chain(sys.builtin_module_names, map(attrgetter('name'), pkgutil.iter_modules()))
-        return frozenset(name for name in modlist if not name.startswith('_'))
+        modlist = chain(
+            sys.builtin_module_names, map(attrgetter("name"), pkgutil.iter_modules())
+        )
+        return frozenset(name for name in modlist if not name.startswith("_"))
 
     def exceptions(self, exc_cls=Exception):
         exc_names = [exc.__name__ for exc in exc_cls.__subclasses__()]
@@ -154,48 +160,52 @@ class ImprovedCompleter(rlcompleter.Completer):
     def startswith_filter(self, text, names, striptext=None):
         filtered = [name for name in names if name.startswith(text)]
         if striptext:
-            return [name.replace(striptext, '') for name in filtered]
+            return [name.replace(striptext, "") for name in filtered]
         return filtered
 
     def get_path_matches(self, text):
-        return [f'{item}{os.path.sep}' if os.path.isdir(item) else item
-                for item in glob.iglob(f'{text}**')]
+        return [
+            f"{item}{os.path.sep}" if os.path.isdir(item) else item
+            for item in glob.iglob(f"{text}**")
+        ]
 
     def get_import_matches(self, text, words):
-        if any([(len(words) == 2 and not text),
-                (len(words) == 3 and text and 'import'.startswith(text))]):
-            return ['import ']
+        if any(
+            [
+                (len(words) == 2 and not text),
+                (len(words) == 3 and text and "import".startswith(text)),
+            ]
+        ):
+            return ["import "]
 
         if len(words) <= 2:
             # import p<tab> / from p<tab>
-            modname, _, _ = text.partition('.')
+            modname, _, _ = text.partition(".")
             if modname in self.pkglist:
                 return self.startswith_filter(text, self.pkg_contents(modname))
             return self.startswith_filter(text, self.modlist)
 
-        if len(words) >= 3 and words[2] == 'import':
+        if len(words) >= 3 and words[2] == "import":
             # from pkg.sub import na<tab>
             namespace = words[1]
-            pkg, _, _ = namespace.partition('.')
+            pkg, _, _ = namespace.partition(".")
             if pkg in self.pkglist:
                 # from pkg.sub import na<tab>
-                match_text = '.'.join((namespace, text))
-                if (
-                    matches := self.startswith_filter(
-                        match_text, self.pkg_contents(pkg), striptext=f'{namespace}.'
-                    )
+                match_text = ".".join((namespace, text))
+                if matches := self.startswith_filter(
+                    match_text, self.pkg_contents(pkg), striptext=f"{namespace}."
                 ):
                     return matches
 
             # from module import na<ta>
             mod = importlib.import_module(namespace)
-            return self.startswith_filter(text, getattr(mod, '__all__', dir(mod)))
+            return self.startswith_filter(text, getattr(mod, "__all__", dir(mod)))
 
     def complete(self, text, state, line=None):
         if not line:
             line = readline.get_line_buffer()
 
-        if line == '' or line.isspace():
+        if line == "" or line.isspace():
             return None if state else config.ONE_INDENT
 
         words = line.split()
@@ -203,13 +213,17 @@ class ImprovedCompleter(rlcompleter.Completer):
             # - this is the first completion is being attempted for
             # text, we need to populate self.matches, just like
             # super().complete()
-            if line.startswith(('from ', 'import ')):
+            if line.startswith(("from ", "import ")):
                 self.matches = self.get_import_matches(text, words)
-            elif words[0] in ('raise', 'except'):
-                self.matches = self.startswith_filter(text.lstrip('('), self.exceptions())
+            elif words[0] in ("raise", "except"):
+                self.matches = self.startswith_filter(
+                    text.lstrip("("), self.exceptions()
+                )
             elif os.path.sep in text:
                 self.matches = self.get_path_matches(
-                    os.path.expanduser(text) if config.COMPLETION_EXPANDS_TILDE else text
+                    os.path.expanduser(text)
+                    if config.COMPLETION_EXPANDS_TILDE
+                    else text
                 )
             elif "." in text:
                 self.matches = self.attr_matches(text)
@@ -218,7 +232,7 @@ class ImprovedCompleter(rlcompleter.Completer):
 
             if len(self.matches) == 1:
                 match = self.matches[0]
-                if keyword.iskeyword(match) and match in ('raise', 'except'):
+                if keyword.iskeyword(match) and match in ("raise", "except"):
                     self.matches.extend(self.exceptions())
 
                 if match and match.endswith(os.path.sep):
@@ -271,8 +285,8 @@ class ImprovedConsole(InteractiveConsole):
 
     def __init__(self, *args, **kwargs):
         self.session_history = []  # This holds the last executed statements
-        self.buffer = []           # This holds the statement to be executed
-        self._indent = ''
+        self.buffer = []  # This holds the statement to be executed
+        self._indent = ""
         super(ImprovedConsole, self).__init__(*args, **kwargs)
         self.init_color_functions()
         self.init_readline()
@@ -284,29 +298,30 @@ class ImprovedConsole(InteractiveConsole):
             config.LIST_CMD: self.process_list_cmd,
             config.SH_EXEC: self.process_sh_cmd,
             config.HELP_CMD: self.process_help_cmd,
-            config.TOGGLE_AUTO_INDENT_CMD: self.toggle_auto_indent
+            config.TOGGLE_AUTO_INDENT_CMD: self.toggle_auto_indent,
         }
         # - regex to identify and extract commands and their arguments
         self.commands_re = re.compile(
-            r'(?P<cmd>{})\s*(?P<args>[^(]*)'.format(
-                '|'.join(re.escape(cmd) for cmd in self.commands)
+            r"(?P<cmd>{})\s*(?P<args>[^(]*)".format(
+                "|".join(re.escape(cmd) for cmd in self.commands)
             )
         )
 
     def _doc_to_usage(method):
         def inner(self, arg):
             arg = arg.strip()
-            if arg.startswith(('-h', '--help')):
+            if arg.startswith(("-h", "--help")):
                 return self.writeline(blue(method.__doc__.strip()))
             return method(self, arg)
+
         return inner
 
     def init_color_functions(self):
-        """Populates globals dict with some helper functions for colorizing text
-        """
+        """Populates globals dict with some helper functions for colorizing text"""
+
         def colorize(color_code, text, bold=True, readline_workaround=False):
-            reset = '\033[0m'
-            color = '\033[{0}{1}m'.format('1;' if bold else '', color_code)
+            reset = "\033[0m"
+            color = "\033[{0}{1}m".format("1;" if bold else "", color_code)
             # - reason for readline_workaround: http://bugs.python.org/issue20359
             if readline_workaround:
                 return f"\001{color}\002{text}\001{reset}\002"
@@ -314,13 +329,12 @@ class ImprovedConsole(InteractiveConsole):
 
         g = globals()
         for code, color in enumerate(
-            ['red', 'green', 'yellow', 'blue', 'purple', 'cyan', 'grey'], 31
+            ["red", "green", "yellow", "blue", "purple", "cyan", "grey"], 31
         ):
             g[color] = partial(colorize, code)
 
     def init_readline(self):
-        """Activates history and tab completion
-        """
+        """Activates history and tab completion"""
         # - 1. history stuff
         # - mainly borrowed from site.enablerlcompleter() from py3.4+,
         # we can't simply call site.enablerlcompleter() because its
@@ -330,11 +344,11 @@ class ImprovedConsole(InteractiveConsole):
 
         # Reading the initialization (config) file may not be enough to set a
         # completion key, so we set one first and then read the file.
-        readline_doc = getattr(readline, '__doc__', '')
-        if readline_doc is not None and 'libedit' in readline_doc:
-            readline.parse_and_bind('bind ^I rl_complete')
+        readline_doc = getattr(readline, "__doc__", "")
+        if readline_doc is not None and "libedit" in readline_doc:
+            readline.parse_and_bind("bind ^I rl_complete")
         else:
-            readline.parse_and_bind('tab: complete')
+            readline.parse_and_bind("tab: complete")
 
         try:
             readline.read_init_file()
@@ -379,17 +393,16 @@ class ImprovedConsole(InteractiveConsole):
         ssh connection.
         """
         prompt_color = green if sys.version_info.major == 2 else yellow
-        sys.ps1 = prompt_color('>>> ', readline_workaround=True)
-        sys.ps2 = red('... ', readline_workaround=True)
+        sys.ps1 = prompt_color(">>> ", readline_workaround=True)
+        sys.ps2 = red("... ", readline_workaround=True)
         # - if we are over a remote connection, modify the ps1
-        if os.getenv('SSH_CONNECTION'):
-            _, _, this_host, _ = os.getenv('SSH_CONNECTION').split()
-            sys.ps1 = prompt_color(f'[{this_host}]>>> ', readline_workaround=True)
-            sys.ps2 = red(f'[{this_host}]... ', readline_workaround=True)
+        if os.getenv("SSH_CONNECTION"):
+            _, _, this_host, _ = os.getenv("SSH_CONNECTION").split()
+            sys.ps1 = prompt_color(f"[{this_host}]>>> ", readline_workaround=True)
+            sys.ps2 = red(f"[{this_host}]... ", readline_workaround=True)
 
     def init_pprint(self):
-        """Activates pretty-printing of output values.
-        """
+        """Activates pretty-printing of output values."""
         keys_re = re.compile(r'([\'\("]+(.*?[\'\)"]: ))+?')
         color_dict = partial(keys_re.sub, lambda m: purple(m.group()))
         format_func = pprint.pformat
@@ -402,12 +415,18 @@ class ImprovedConsole(InteractiveConsole):
                     rows, cols = os.get_teminal_size()
                 except AttributeError:
                     try:
-                        rows, cols = map(int, subprocess.check_output(['stty', 'size']).split())
+                        rows, cols = map(
+                            int, subprocess.check_output(["stty", "size"]).split()
+                        )
                     except Exception:
                         cols = 80
                 formatted = format_func(value, width=cols)
-                print(color_dict(formatted) if issubclass(type(value), dict) else blue(formatted))
-            self.locals['_'] = value
+                print(
+                    color_dict(formatted)
+                    if issubclass(type(value), dict)
+                    else blue(formatted)
+                )
+            self.locals["_"] = value
 
         sys.displayhook = pprint_callback
 
@@ -420,23 +439,23 @@ class ImprovedConsole(InteractiveConsole):
 
     @_doc_to_usage
     def toggle_auto_indent(self, _):
-        """{config.TOGGLE_AUTO_INDENT_CMD} - Toggles the auto-indentation behavior
-        """
+        """{config.TOGGLE_AUTO_INDENT_CMD} - Toggles the auto-indentation behavior"""
         hook = None if config.AUTO_INDENT else self.auto_indent_hook
-        msg = '# Auto-Indent has been {}abled\n'.format('en' if hook else 'dis')
+        msg = "# Auto-Indent has been {}abled\n".format("en" if hook else "dis")
         config.AUTO_INDENT = bool(hook)
 
         if hook is None:
-            msg += ('# End of blocks will be detected after 3 empty lines\n'
-                    f'# Re-type {config.TOGGLE_AUTO_INDENT_CMD} on a line by itself to enable')
+            msg += (
+                "# End of blocks will be detected after 3 empty lines\n"
+                f"# Re-type {config.TOGGLE_AUTO_INDENT_CMD} on a line by itself to enable"
+            )
 
         readline.set_pre_input_hook(hook)
         print(grey(msg, bold=False))
-        return ''
+        return ""
 
-    def raw_input(self, prompt=''):
-        """Read the input and delegate if necessary.
-        """
+    def raw_input(self, prompt=""):
+        """Read the input and delegate if necessary."""
         line = super(ImprovedConsole, self).raw_input(prompt)
         empty_lines = 3 if line else 1
         while not config.AUTO_INDENT and empty_lines < 3:
@@ -445,7 +464,7 @@ class ImprovedConsole(InteractiveConsole):
         return self._cmd_handler(line)
 
     def _cmd_handler(self, line):
-        if (matches := self.commands_re.match(line)):
+        if matches := self.commands_re.match(line):
             command, args = matches.groups()
             line = self.commands[command](args)
         elif line.endswith(config.DOC_CMD):
@@ -454,43 +473,45 @@ class ImprovedConsole(InteractiveConsole):
                 # - strip off the '??' and the possible tab-completed
                 # '(' or '.' and replace inner '.' with '+' to create the
                 # search query string
-                line = line.rstrip(f'{config.DOC_CMD}.(').replace('.', '+')
+                line = line.rstrip(f"{config.DOC_CMD}.(").replace(".", "+")
                 webbrowser.open(config.DOC_URL.format(sys=sys, term=line))
-                line = ''
+                line = ""
             else:
-                line = line.rstrip(f'{config.DOC_CMD}.(')
+                line = line.rstrip(f"{config.DOC_CMD}.(")
                 if not line:
-                    line = 'dir()'
+                    line = "dir()"
                 elif keyword.iskeyword(line):
                     line = f'help("{line}")'
                 else:
-                    line = f'print({line}.__doc__)'
-        elif config.AUTO_INDENT and (line.startswith(config.ONE_INDENT) or self._indent):
+                    line = f"print({line}.__doc__)"
+        elif config.AUTO_INDENT and (
+            line.startswith(config.ONE_INDENT) or self._indent
+        ):
             if line.strip():
                 # if non empty line with an indent, check if the indent
                 # level has been changed
-                leading_space = line[:line.index(line.lstrip()[0])]
+                leading_space = line[: line.index(line.lstrip()[0])]
                 if self._indent != leading_space:
                     # indent level changed, update self._indent
                     self._indent = leading_space
             else:
                 # - empty line, decrease indent
-                self._indent = self._indent[:-len(config.ONE_INDENT)]
+                self._indent = self._indent[: -len(config.ONE_INDENT)]
                 line = self._indent
-        elif line.startswith('%'):
-            self.writeline('Y U NO LIKE ME?')
+        elif line.startswith("%"):
+            self.writeline("Y U NO LIKE ME?")
             return line
-        return line or ''
+        return line or ""
 
     def push(self, line):
         """Wrapper around InteractiveConsole's push method for adding an
         indent on start of a block.
         """
-        if (more := super(ImprovedConsole, self).push(line)):
-            if line.endswith((':', '[', '{', '(')):
+        if more := super(ImprovedConsole, self).push(line):
+            if line.endswith((":", "[", "{", "(")):
                 self._indent += config.ONE_INDENT
         else:
-            self._indent = ''
+            self._indent = ""
         return more
 
     def runcode(self, code):
@@ -516,17 +537,15 @@ class ImprovedConsole(InteractiveConsole):
             self.showtraceback()
 
     def write(self, data):
-        """Write out data to stderr
-        """
-        sys.stderr.write(data if data.startswith('\033[') else red(data))
+        """Write out data to stderr"""
+        sys.stderr.write(data if data.startswith("\033[") else red(data))
 
     def writeline(self, data):
-        """Same as write but adds a newline to the end
-        """
-        return self.write(f'{data}\n')
+        """Same as write but adds a newline to the end"""
+        return self.write(f"{data}\n")
 
     def resetbuffer(self):
-        self._indent = previous = ''
+        self._indent = previous = ""
         for line in self.buffer:
             # - replace multiple empty lines with one before writing to session history
             stripped = line.strip()
@@ -536,10 +555,9 @@ class ImprovedConsole(InteractiveConsole):
         return super(ImprovedConsole, self).resetbuffer()
 
     def _mktemp_buffer(self, lines):
-        """Writes lines to a temp file and returns the filename.
-        """
-        with NamedTemporaryFile(mode='w+', suffix='.py', delete=False) as tempbuf:
-            tempbuf.write('\n'.join(lines))
+        """Writes lines to a temp file and returns the filename."""
+        with NamedTemporaryFile(mode="w+", suffix=".py", delete=False) as tempbuf:
+            tempbuf.write("\n".join(lines))
         return tempbuf.name
 
     def showtraceback(self, *args):
@@ -552,26 +570,31 @@ class ImprovedConsole(InteractiveConsole):
         self._skip_subsequent = True
         return super(ImprovedConsole, self).showtraceback(*args)
 
-    def _exec_from_file(self, open_fd, quiet=False, skip_history=False,
-                        print_comments=config.POST_EDIT_PRINT_COMMENTS):
+    def _exec_from_file(
+        self,
+        open_fd,
+        quiet=False,
+        skip_history=False,
+        print_comments=config.POST_EDIT_PRINT_COMMENTS,
+    ):
         self._skip_subsequent = False
-        previous = ''
+        previous = ""
         for stmt in open_fd:
             # - skip over multiple empty lines
             stripped = stmt.strip()
-            if stripped == previous == '':
+            if stripped == previous == "":
                 continue
 
             # - if line is a comment, print (if required) and move to
             # next line
-            if stripped.startswith('#'):
+            if stripped.startswith("#"):
                 if print_comments and not quiet:
                     self.write(grey(f"... {stmt}", bold=False))
                 continue
 
             # - process line only if we haven't encountered an error yet
             if not self._skip_subsequent:
-                line = stmt.strip('\n')
+                line = stmt.strip("\n")
                 if line and not line[0].isspace():
                     # - end of previous statement, submit buffer for
                     # execution
@@ -590,19 +613,21 @@ class ImprovedConsole(InteractiveConsole):
                 if not skip_history:
                     readline.add_history(line)
             previous = stripped
-        self.push('')
+        self.push("")
 
     def lookup(self, name, namespace=None):
         """Lookup the (dotted) object specified with the string `name`
         in the specified namespace or in the current namespace if
         unspecified.
         """
-        name, _, components = name.partition('.')
-        obj = getattr(namespace, name, namespace) if namespace else self.locals.get(name)
+        name, _, components = name.partition(".")
+        obj = (
+            getattr(namespace, name, namespace) if namespace else self.locals.get(name)
+        )
         return self.lookup(components, obj) if components else obj
 
     @_doc_to_usage
-    def process_edit_cmd(self, arg=''):
+    def process_edit_cmd(self, arg=""):
         """{config.EDIT_CMD} [object|filename]
 
         Open {config.EDITOR} with session history, provided filename or
@@ -622,10 +647,10 @@ class ImprovedConsole(InteractiveConsole):
           source file of the object and it is opened if found. Else the
           argument is treated as a filename.
         """
-        line_num_opt = ''
+        line_num_opt = ""
         if arg:
             try:
-                if (obj := self.lookup(arg)):
+                if obj := self.lookup(arg):
                     filename = inspect.getsourcefile(obj)
                     _, line_no = inspect.getsourcelines(obj)
                     line_num_opt = config.LINE_NUM_OPT.format(line_no=line_no)
@@ -637,12 +662,12 @@ class ImprovedConsole(InteractiveConsole):
             # - make a list of all lines in history, commenting any non-blank lines.
             history = self.session_history or open(config.HISTFILE)
             filename = self._mktemp_buffer(
-                f'# {line}' if line.strip() else ''
-                for line in (line.strip('\n') for line in history)
+                f"# {line}" if line.strip() else ""
+                for line in (line.strip("\n") for line in history)
             )
 
         # - shell out to the editor
-        rc = os.system(f'{config.EDITOR} {line_num_opt} {filename}')
+        rc = os.system(f"{config.EDITOR} {line_num_opt} {filename}")
 
         # - if arg was not provided (ie: we edited history), execute
         # un-commented lines in the current namespace
@@ -650,12 +675,17 @@ class ImprovedConsole(InteractiveConsole):
             if rc == 0:
                 # - if HISTFILE contents were edited (ie: EDIT_CMD in a
                 # brand new session), don't print commented out lines
-                print_comments = (False if history != self.session_history
-                                  else config.POST_EDIT_PRINT_COMMENTS)
+                print_comments = (
+                    False
+                    if history != self.session_history
+                    else config.POST_EDIT_PRINT_COMMENTS
+                )
                 with open(filename) as edits:
                     self._exec_from_file(edits, print_comments=print_comments)
             else:
-                self.writeline(f'{config.EDITOR} exited with an error code. Skipping execution.')
+                self.writeline(
+                    f"{config.EDITOR} exited with an error code. Skipping execution."
+                )
             os.unlink(filename)
 
     @_doc_to_usage
@@ -686,17 +716,23 @@ class ImprovedConsole(InteractiveConsole):
             try:
                 cmd = cmd.format(**self.locals)
                 cmd = shlex.split(cmd)
-                if cmd[0] == 'cd':
-                    os.chdir(os.path.expanduser(os.path.expandvars(' '.join(cmd[1:]) or '${HOME}')))
+                if cmd[0] == "cd":
+                    os.chdir(
+                        os.path.expanduser(
+                            os.path.expandvars(" ".join(cmd[1:]) or "${HOME}")
+                        )
+                    )
                 else:
-                    completed = subprocess.run(cmd, capture_output=True, env=os.environ, text=True)
+                    completed = subprocess.run(
+                        cmd, capture_output=True, env=os.environ, text=True
+                    )
                     out, rc = completed.stdout, completed.returncode
                     print(red(out) if rc else green(out, bold=False))
-                    self.locals['_'] = completed
+                    self.locals["_"] = completed
             except Exception:
                 self.showtraceback()
         else:
-            if os.getenv('SSH_CONNECTION'):
+            if os.getenv("SSH_CONNECTION"):
                 # I use the bash function similar to the one below in my
                 # .bashrc to directly open a python prompt on remote
                 # systems I log on to.
@@ -709,11 +745,12 @@ class ImprovedConsole(InteractiveConsole):
 
     @_doc_to_usage
     def process_list_cmd(self, arg):
-        """{config.LIST_CMD} <object> - List source code for object, if possible.
-        """
+        """{config.LIST_CMD} <object> - List source code for object, if possible."""
         if not arg:
-            return self.writeline('source list command requires an '
-                                  f'argument (eg: {config.LIST_CMD} foo)')
+            return self.writeline(
+                "source list command requires an "
+                f"argument (eg: {config.LIST_CMD} foo)"
+            )
         try:
             src_lines, offset = inspect.getsourcelines(self.lookup(arg))
         except (IOError, TypeError, NameError) as e:
@@ -727,28 +764,29 @@ class ImprovedConsole(InteractiveConsole):
             if keyword.iskeyword(arg):
                 self.push(f'help("{arg}")')
             elif arg in self.commands:
-                self.commands[arg]('-h')
+                self.commands[arg]("-h")
             else:
-                self.push(f'help({arg})')
+                self.push(f"help({arg})")
         else:
             print(cyan(self.__doc__).format(**config.__dict__))
 
     def interact(self):
-        """A forgiving wrapper around InteractiveConsole.interact()
-        """
-        venv_rc_done = cyan('(no venv rc found)')
+        """A forgiving wrapper around InteractiveConsole.interact()"""
+        venv_rc_done = cyan("(no venv rc found)")
         try:
             with open(config.VENV_RC) as venv_rc:
                 self._exec_from_file(venv_rc, quiet=True, skip_history=True)
             # - clear out session_history for venv_rc commands
             self.session_history = []
-            venv_rc_done = green('Successfully executed venv rc !')
+            venv_rc_done = green("Successfully executed venv rc !")
         except IOError:
             pass
 
-        banner = (f"Welcome to the ImprovedConsole (version {__version__})\n"
-                  f"Type in {config.HELP_CMD} for list of features.\n"
-                  f"{venv_rc_done}")
+        banner = (
+            f"Welcome to the ImprovedConsole (version {__version__})\n"
+            f"Type in {config.HELP_CMD} for list of features.\n"
+            f"{venv_rc_done}"
+        )
 
         retries = 2
         while retries:
@@ -759,14 +797,23 @@ class ImprovedConsole(InteractiveConsole):
                 break
             except Exception:
                 import traceback
+
                 retries -= 1
-                print(red("I'm sorry, ImprovedConsole could not handle that !\n"
-                          "Please report an error with this traceback, "
-                          "I would really appreciate that !"))
+                print(
+                    red(
+                        "I'm sorry, ImprovedConsole could not handle that !\n"
+                        "Please report an error with this traceback, "
+                        "I would really appreciate that !"
+                    )
+                )
                 traceback.print_exc()
 
-                print(red("I shall try to restore the crashed session.\n"
-                          "If the crash occurs again, please exit the session"))
+                print(
+                    red(
+                        "I shall try to restore the crashed session.\n"
+                        "If the crash occurs again, please exit the session"
+                    )
+                )
                 banner = blue("Your crashed session has been restored")
             else:
                 # exit with a Ctrl-D
@@ -776,8 +823,8 @@ class ImprovedConsole(InteractiveConsole):
         sys.exit()
 
 
-if not os.getenv('SKIP_PYMP'):
+if not os.getenv("SKIP_PYMP"):
     # - create our pimped out console and fire it up !
     pymp = ImprovedConsole(locals=CLEAN_NS)
-    pymp.locals['__pymp__'] = pymp
+    pymp.locals["__pymp__"] = pymp
     pymp.interact()

--- a/pythonrc.py
+++ b/pythonrc.py
@@ -74,9 +74,8 @@ import shlex
 import signal
 import subprocess
 import webbrowser
-
 from code import InteractiveConsole
-from functools import partial, lru_cache, cached_property
+from functools import cached_property, lru_cache, partial
 from itertools import chain
 from operator import attrgetter
 from tempfile import NamedTemporaryFile

--- a/pythonrc.py
+++ b/pythonrc.py
@@ -85,7 +85,7 @@ from functools import cached_property, lru_cache, partial
 from itertools import chain
 from operator import attrgetter
 from tempfile import NamedTemporaryFile
-from types import FunctionType, ModuleType, SimpleNamespace
+from types import FunctionType, SimpleNamespace
 
 __version__ = "0.9.0"
 
@@ -904,37 +904,6 @@ class ImprovedConsole(InteractiveConsole):
         else:
             for line_no, line in enumerate(src_lines, offset + 1):
                 self.write(cyan(f"{line_no:03d}: {line}"))
-
-    @_doc_to_usage
-    def process_reload_cmd(self, arg):
-        """{config.RELOAD_CMD} <object> - Reload object, if possible.
-
-        - if argument is a module, simply call importlib.reload() for it.
-
-        - if argument is not a module, try hard to re-execute the
-        (presumably updated) source code in the namespace of the object,
-        in effect reloading it.
-
-        credit: inspired by the description at https://github.com/hoh/reloadr
-        """
-        if not arg:
-            return self.writeline(
-                "reload command requires an " f"argument (eg: {config.RELOAD_CMD} foo)"
-            )
-
-        try:
-            obj = self.lookup(arg)
-            if isinstance(obj, ModuleType):
-                self.locals[arg] = importlib.reload(obj)
-            else:
-                namespace = inspect.getmodule(obj)
-                exec(
-                    compile(inspect.getsource(obj), namespace.__file__, "exec"),
-                    namespace.__dict__,
-                    self.locals,
-                )
-        except OSError as e:
-            self.writeline(e)
 
     def process_help_cmd(self, arg):
         if arg:


### PR DESCRIPTION
# pythonrc.py is now `async` capable !

Now, you can declare `async def` functions and `await` on them from the python prompt. This ability is enabled using the `config.TOGGLE_ASYNCIO_LOOP_CMD` (defaults to `\A`),

## Details
This functionality is mostly borrowed from the stdlib implementation of `asyncio.__main__`. The essential idea being that on invoking the `\A` command:
* a new asyncio loop is started in the main interpreter thread
* a new (nested) interpreter session is launched in a separate thread (which shares the stdin/stdout/stderror since we don't do anything special beyond launching the new session
* the asyncio loop will continue to run until `\A` is invoked again
  * at which point the loop is stopped ...*but* the nested interpreter is not automatically exited
  * when the nested interpreter is exited (for instance using `Ctrl+d`), you are landed back into the original instance of the interpreter
* a subsequent `\A` will restart the thread (potentially, also restarting the nested interpreter, if that was exited)

![image](https://user-images.githubusercontent.com/101819/181613695-4190fba4-418f-4edc-81b7-a637f395109a.png)

Other changes:
- Start using `isort --profile black pythonrc.py`
- black-en pythonrc.py
- mypy clean pythonrc.py
- Edit history with cursor at the last line